### PR TITLE
It appears the binary name from MinGW has changed. Updating the name.

### DIFF
--- a/Make.win32
+++ b/Make.win32
@@ -3,7 +3,7 @@
 # on another platform.  Otherwise the binaries are just
 # named gcc, etc.
 
-MING=i586-mingw32msvc-
+MING=i686-w64-mingw32-
 #MING=
 AR=$(MING)ar
 CC=$(MING)gcc


### PR DESCRIPTION
Pulled down the source and went to compile the windows binary on my linux box, and saw that the compiler wasn't being found. Some digging suggests that mingw now comes with `i686-w64-mingw32`, and no longer comes with `i586-mingw32msvc`. The[ general usage](https://sourceforge.net/p/mingw-w64/wiki2/GeneralUsageInstructions/) page mentions the i686 variant, for example. So, figured I'd push that over here, since others may run into the issue.

Thanks!
