### PR TITLE
Add the ability to make the application fullscreen and borderless on MS.

### DIFF
--- a/gui-win32/screen.c
+++ b/gui-win32/screen.c
@@ -39,6 +39,8 @@ static int readybit;
 static Rendez	rend;
 
 Point	ZP;
+uint windowStyle;
+const uint BORDERLESS = WS_MAXIMIZEBOX | WS_MINIMIZEBOX | WS_THICKFRAME | WS_SYSMENU | WS_DLGFRAME | WS_CLIPSIBLINGS | WS_VISIBLE | WS_POPUP ^ WS_MINIMIZE | WS_MAXIMIZE;
 
 static int
 isready(void*a)
@@ -192,12 +194,12 @@ winproc(void *a)
 	wc.lpszMenuName = 0;
 	wc.lpszClassName = L"9pmgraphics";
 	RegisterClass(&wc);
-
+    windowStyle = WS_OVERLAPPEDWINDOW;
 	window = CreateWindowEx(
 		0,			/* extended style */
 		L"9pmgraphics",		/* class */
 		L"drawterm screen",		/* caption */
-		WS_OVERLAPPEDWINDOW,    /* style */
+		windowStyle,    /* style */
 		CW_USEDEFAULT,		/* init. x pos */
 		CW_USEDEFAULT,		/* init. y pos */
 		CW_USEDEFAULT,		/* init. x size */
@@ -440,6 +442,18 @@ WindowProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 		case VK_RIGHT:
 			kbdputc(kbdq, Kright);
 			break;
+        case VK_F11:
+            if (windowStyle == WS_OVERLAPPEDWINDOW)
+                windowStyle = BORDERLESS;
+            else
+                windowStyle = WS_OVERLAPPEDWINDOW;
+
+            SetWindowLongPtr(hwnd, -16, windowStyle);
+            ShowWindow(hwnd, SW_SHOWNORMAL);
+            RECT rcWnd;
+            GetWindowRect(hwnd,&rcWnd);
+            SetWindowPos(hwnd,(HWND)0,rcWnd.left,rcWnd.top,(rcWnd.right-rcWnd.left),(rcWnd.bottom-rcWnd.top),SWP_NOMOVE); //forces a refresh of the screen
+            ShowWindow(hwnd, SW_SHOWMAXIMIZED);
 		}
 		break;
 

--- a/gui-win32/screen.c
+++ b/gui-win32/screen.c
@@ -194,7 +194,7 @@ winproc(void *a)
 	wc.lpszMenuName = 0;
 	wc.lpszClassName = L"9pmgraphics";
 	RegisterClass(&wc);
-    windowStyle = WS_OVERLAPPEDWINDOW;
+	windowStyle = WS_OVERLAPPEDWINDOW;
 	window = CreateWindowEx(
 		0,			/* extended style */
 		L"9pmgraphics",		/* class */
@@ -442,18 +442,18 @@ WindowProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 		case VK_RIGHT:
 			kbdputc(kbdq, Kright);
 			break;
-        case VK_F11:
-            if (windowStyle == WS_OVERLAPPEDWINDOW)
-                windowStyle = BORDERLESS;
-            else
-                windowStyle = WS_OVERLAPPEDWINDOW;
+		case VK_F11:
+			if (windowStyle == WS_OVERLAPPEDWINDOW)
+				windowStyle = BORDERLESS;
+			else
+				windowStyle = WS_OVERLAPPEDWINDOW;
 
-            SetWindowLongPtr(hwnd, -16, windowStyle);
-            ShowWindow(hwnd, SW_SHOWNORMAL);
-            RECT rcWnd;
-            GetWindowRect(hwnd,&rcWnd);
-            SetWindowPos(hwnd,(HWND)0,rcWnd.left,rcWnd.top,(rcWnd.right-rcWnd.left),(rcWnd.bottom-rcWnd.top),SWP_NOMOVE); //forces a refresh of the screen
-            ShowWindow(hwnd, SW_SHOWMAXIMIZED);
+			SetWindowLongPtr(hwnd, -16, windowStyle);
+			ShowWindow(hwnd, SW_SHOWNORMAL);
+			RECT rcWnd;
+			GetWindowRect(hwnd,&rcWnd);
+			SetWindowPos(hwnd,(HWND)0,rcWnd.left,rcWnd.top,(rcWnd.right-rcWnd.left),(rcWnd.bottom-rcWnd.top),SWP_NOMOVE); //forces a refresh of the screen
+			ShowWindow(hwnd, SW_SHOWMAXIMIZED);
 		}
 		break;
 


### PR DESCRIPTION
On Windows, I got mildly annoyed by the full-screened application still having a title bar at the top. So, I added the ability to hit 'F11' in order to have the application lose its title bar and fullscreen (similar to the behavior of web browsers and F11). Hitting F11 again returns the screen to being a normal titled window. 

Here's a gif of the behavior: https://gfycat.com/DishonestFaroffFlee

I figured it might be appreciated by the other person who uses drawterm on Windows.
