### PR TITLE
kern/devfs-posix: disallow renaming file to an existing file

### DIFF
--- a/kern/devfs-posix.c
+++ b/kern/devfs-posix.c
@@ -438,6 +438,8 @@ fswstat(Chan *c, uchar *buf, int n)
 		strcpy(new, old);
 		p = strrchr(new, '/');
 		strcpy(p+1, d.name);
+		if(lstat(new, &stbuf) >= 0)
+			error(Eexist);
 		if(rename(old, new) < 0)
 			error(strerror(errno));
 	}


### PR DESCRIPTION
This behavior matches 9p.

Plan 9 wstat(5):

	The wstat request can change some of the file status
	information. The name can be changed by anyone with write
	permission in the parent directory; it is an error to change the
	name to that of an existing file.

Linux rename(2):

	If newpath already exists, it will be atomically replaced, so
	that there is no point at which another process attempting to
	access newpath will find it missing. However, there will
	probably be a window in which both oldpath and newpath refer to
	the file being renamed.