### PR TITLE
ci: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
Dependabot automatically maintains GitHub Actions workflows by sending Pull Requests to project when action updates are released. Dependabot labels the pull requests 'ci: bump actions/checkout from v3 to v4'. Dependabot opens a maximum of five Pull Requests at a time and reviews the need for PRs once a week.